### PR TITLE
completed limit and order-by filters

### DIFF
--- a/client/src/app/todos/todo-list.component.html
+++ b/client/src/app/todos/todo-list.component.html
@@ -46,6 +46,28 @@
           </mat-form-field>
         </div>
 
+         <div class="flex-row gap-8 flex-wrap">
+
+          <mat-form-field class="input-field">
+            <mat-label>Limit</mat-label>
+            <input matInput data-test="todoLimitInput" type="number" min="1" max="999" placeholder="Limit todos" [(ngModel)]="todoLimit">
+            <mat-hint>Filtered on server</mat-hint>
+          </mat-form-field>
+
+
+        <mat-form-field class="input-field">
+            <mat-label>Order By</mat-label>
+            <mat-select [(ngModel)]="todoOrder" data-test="todoOrderSelect">
+              <mat-option>--</mat-option>
+              <mat-option value="category">Category</mat-option>
+              <mat-option value="status">Status</mat-option>
+              <mat-option value="owner">Owner</mat-option>
+              <mat-option value="body">Body</mat-option>
+            </mat-select>
+            <mat-hint>Filtered on server</mat-hint>
+          </mat-form-field>
+        </div>
+
         <div class="flex-row gap-8 flex-wrap">
           <label for="viewType">View type: </label>
           <mat-radio-group aria-label="View type" [(ngModel)]="viewType" data-test="viewTypeRadio">

--- a/client/src/app/todos/todo-list.component.spec.ts
+++ b/client/src/app/todos/todo-list.component.spec.ts
@@ -50,7 +50,7 @@ describe('Todo list', () => {
     // todoList.userRole.set('admin');
     todoList.todoStatus.set("complete")
     fixture.detectChanges();
-    expect(spy).toHaveBeenCalledWith({ status: "complete", body: undefined });
+    expect(spy).toHaveBeenCalledWith({ status: "complete", limit: undefined, orderBy: undefined, body: undefined });
   });
 
   it('should call getTodos() when todoBody signal changes', () => {
@@ -58,22 +58,24 @@ describe('Todo list', () => {
     // todoList.userRole.set('admin');
     todoList.todoBody.set('testing... testing...')
     fixture.detectChanges();
-    expect(spy).toHaveBeenCalledWith({ body: 'testing... testing...', status: undefined });
+    expect(spy).toHaveBeenCalledWith({ body: 'testing... testing...', limit: undefined, orderBy: undefined, status: undefined });
   });
 
-  // it('should call getTodos() when todoRole signal changes', () => {
-  //   const spy = spyOn(todoService, 'getTodos').and.callThrough();
-  //   todoList.userRole.set('admin');
-  //   fixture.detectChanges();
-  //   expect(spy).toHaveBeenCalledWith({ role: 'admin', age: undefined });
-  // });
+  it('should call getTodos() when todoLimit signal changes', () => {
+    const spy = spyOn(todoService, 'getTodos').and.callThrough();
+    // todoList.userRole.set('admin');
+    todoList.todoLimit.set(99)
+    fixture.detectChanges();
+    expect(spy).toHaveBeenCalledWith({ limit: 99, body: undefined, status: undefined, orderBy: undefined, });
+  });
 
-  // it('should call getTodos() when todoAge signal changes', () => {
-  //   const spy = spyOn(todoService, 'getTodos').and.callThrough();
-  //   todoList.todoAge.set(25);
-  //   fixture.detectChanges();
-  //   expect(spy).toHaveBeenCalledWith({ role: undefined, age: 25 });
-  // });
+  it('should call getTodos() when todoOrder signal changes', () => {
+    const spy = spyOn(todoService, 'getTodos').and.callThrough();
+    // todoList.userRole.set('admin');
+    todoList.todoOrder.set('category')
+    fixture.detectChanges();
+    expect(spy).toHaveBeenCalledWith({ orderBy: 'category', status: undefined, limit: undefined, body: undefined});
+  });
 
   it('should not show error message on successful load', () => {
     expect(todoList.errMsg()).toBeUndefined();

--- a/client/src/app/todos/todo-list.component.ts
+++ b/client/src/app/todos/todo-list.component.ts
@@ -59,6 +59,8 @@ export class TodoListComponent {
   todoCategory = signal<string | undefined>(undefined);
   todoBody = signal<string | undefined>(undefined);
   todoStatus = signal<string | undefined>(undefined);
+  todoOrder = signal<string | undefined>(undefined);
+  todoLimit = signal<number | undefined>(undefined);
 
   viewType = signal<'card' | 'list'>('card');
 
@@ -72,16 +74,20 @@ export class TodoListComponent {
   // definition of `serverFilteredUsers` below to trigger updates to the `Observable` there.
   private todoStatus$ = toObservable(this.todoStatus);
   private todoBody$ = toObservable(this.todoBody);
+  private todoLimit$ = toObservable(this.todoLimit);
+  private todoOrder$ = toObservable(this.todoOrder);
 
   // Server side filtering
   serverFilteredTodos =
     toSignal(
-      combineLatest([this.todoStatus$, this.todoBody$]).pipe(
+      combineLatest([this.todoStatus$, this.todoBody$, this.todoLimit$, this.todoOrder$]).pipe(
 
-        switchMap(([status, body]) =>
+        switchMap(([status, body, limit, orderBy]) =>
           this.todoService.getTodos({
             status,
             body,
+            limit,
+            orderBy,
           })
         ),
 

--- a/client/src/app/todos/todo.service.spec.ts
+++ b/client/src/app/todos/todo.service.spec.ts
@@ -57,25 +57,6 @@ describe('TodoService', () => {
     httpTestingController.verify();
   });
 
-  // describe('When getCompanies() is called with no parameters', () => {
-  //   it('calls `api/usersByCompany`', waitForAsync(() => {
-  //     // Mock the `httpClient.get()` method, so that instead of making an HTTP request,
-  //     // it just returns our test data.
-  //     const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(testCompanies));
-
-  //     userService.getCompanies().subscribe(() => {
-  //       // The mocked method (`httpClient.get()`) should have been called
-  //       // exactly one time.
-  //       expect(mockedMethod)
-  //         .withContext('one call')
-  //         .toHaveBeenCalledTimes(1);
-  //       expect(mockedMethod)
-  //         .withContext('talks to the correct endpoint')
-  //         .toHaveBeenCalledWith(userService.usersByCompanyUrl);
-  //     });
-  //   }));
-  // });
-
   describe('When getTodos() is called with no parameters', () => {
     it('calls `api/todos`', waitForAsync(() => {
       // Mock the `httpClient.get()` method, so that instead of making an HTTP request,
@@ -137,59 +118,44 @@ describe('TodoService', () => {
           .toHaveBeenCalledWith(todoService.todoUrl, { params: new HttpParams().set('status', 'incomplete') });
       });
     });
+  });
 
-    // it('correctly calls api/users with multiple filter parameters', () => {
-    //   const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(testUsers));
+  it('correctly calls api/todos with filter parameter \'limit\'', () => {
+    const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(testTodos));
 
-    //   userService.getUsers({ role: 'editor', company: 'IBM', age: 37 }).subscribe(() => {
-    //     // This test checks that the call to `userService.getUsers()` does several things:
-    //     //   * It calls the mocked method (`HttpClient#get()`) exactly once.
-    //     //   * It calls it with the correct endpoint (`userService.userUrl`).
-    //     //   * It calls it with the correct parameters:
-    //     //      * There should be three parameters (this makes sure that there aren't extras).
-    //     //      * There should be a "role:editor" key-value pair.
-    //     //      * And a "company:IBM" pair.
-    //     //      * And a "age:37" pair.
+    todoService.getTodos({ limit: 2 }).subscribe(() => {
+      expect(mockedMethod)
+        .withContext('one call')
+        .toHaveBeenCalledTimes(1);
+      expect(mockedMethod)
+        .withContext('talks to the correct endpoint')
+        .toHaveBeenCalledWith(todoService.todoUrl, { params: new HttpParams().set('limit', 2) });
+    });
+  });
 
-    //     // This gets the arguments for the first (and in this case only) call to the `mockMethod`.
-    //     const [url, options] = mockedMethod.calls.argsFor(0);
-    //     // Gets the `HttpParams` from the options part of the call.
-    //     // `options.param` can return any of a broad number of types;
-    //     // it is in fact an instance of `HttpParams`, and I need to use
-    //     // that fact, so I'm casting it (the `as HttpParams` bit).
-    //     const calledHttpParams: HttpParams = (options.params) as HttpParams;
-    //     expect(mockedMethod)
-    //       .withContext('one call')
-    //       .toHaveBeenCalledTimes(1);
-    //     expect(url)
-    //       .withContext('talks to the correct endpoint')
-    //       .toEqual(userService.userUrl);
-    //     expect(calledHttpParams.keys().length)
-    //       .withContext('should have 3 params')
-    //       .toEqual(3);
-    //     expect(calledHttpParams.get('role'))
-    //       .withContext('role of editor')
-    //       .toEqual('editor');
-    //     expect(calledHttpParams.get('company'))
-    //       .withContext('company being IBM')
-    //       .toEqual('IBM');
-    //     expect(calledHttpParams.get('age'))
-    //       .withContext('age being 37')
-    //       .toEqual('37');
-    //   });
-    // });
+  it('correctly calls api/todos with filter parameter \'orderBy\'', () => {
+    const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(testTodos));
+
+    todoService.getTodos({orderBy: 'status' }).subscribe(() => {
+      expect(mockedMethod)
+        .withContext('one call')
+        .toHaveBeenCalledTimes(1);
+      expect(mockedMethod)
+        .withContext('talks to the correct endpoint')
+        .toHaveBeenCalledWith(todoService.todoUrl, { params: new HttpParams().set('orderBy', 'status') });
+    });
   });
 
   describe('When getTodoById() is given an ID', () => {
     it('calls api/users/id with the correct ID', waitForAsync(() => {
       // We're just picking a Todo  "at random" from our little
       // set of Todos up at the top.
-      const targetUser: Todo = testTodos[1];
-      const targetId: string = targetUser._id;
+      const targetTodo: Todo = testTodos[1];
+      const targetId: string = targetTodo._id;
 
       // Mock the `httpClient.get()` method so that instead of making an HTTP request
       // it just returns one todo from our test data
-      const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(targetUser));
+      const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(targetTodo));
 
       // Call `userService.getUser()` and confirm that the correct call has
       // been made with the correct arguments.
@@ -197,8 +163,9 @@ describe('TodoService', () => {
       // We have to `subscribe()` to the `Observable` returned by `getUserById()`.
       // The `user` argument in the function below is the thing of type Todo returned by
       // the call to `getTodoById()`.
+
       todoService.getTodoById(targetId).subscribe(() => {
-        // The `User` returned by `getUserById()` should be targetUser, but
+        // The `User` returned by `getUserById()` should be targetTodo, but
         // we don't bother with an `expect` here since we don't care what was returned.
         expect(mockedMethod)
           .withContext('one call')
@@ -232,36 +199,6 @@ describe('TodoService', () => {
         expect(todo.category.indexOf(categoryName)).toBeGreaterThanOrEqual(0);
       });
     });
-
-    // it('filters by company', () => {
-    //   const userCompany = 'UMM';
-    //   const filteredUsers = userService.filterUsers(testUsers, { company: userCompany });
-    //   // There should be just one user that has UMM as their company.
-    //   expect(filteredUsers.length).toBe(1);
-    //   // Every returned user's company should contain 'UMM'.
-    //   filteredUsers.forEach(user => {
-    //     expect(user.company.indexOf(userCompany)).toBeGreaterThanOrEqual(0);
-    //   });
-    // });
-
-    // it('filters by name and company', () => {
-    //   // There's only one user (Chris) whose name
-    //   // contains an 'i' and whose company contains
-    //   // an 'M'. There are two whose name contains
-    //   // an 'i' and two whose company contains an
-    //   // an 'M', so this should test combined filtering.
-    //   const userName = 'i';
-    //   const userCompany = 'M';
-    //   const filters = { name: userName, company: userCompany };
-    //   const filteredUsers = userService.filterUsers(testUsers, filters);
-    //   // There should be just one user with these properties.
-    //   expect(filteredUsers.length).toBe(1);
-    //   // Every returned user should have _both_ these properties.
-    //   filteredUsers.forEach(user => {
-    //     expect(user.name.indexOf(userName)).toBeGreaterThanOrEqual(0);
-    //     expect(user.company.indexOf(userCompany)).toBeGreaterThanOrEqual(0);
-    //   });
-    // });
   });
 
   // describe('Adding a user using `addUser()`', () => {

--- a/client/src/app/todos/todo.service.ts
+++ b/client/src/app/todos/todo.service.ts
@@ -31,6 +31,8 @@ export class TodoService {
   private readonly categoryKey = 'category';
   private readonly bodyKey = 'contains';
   private readonly statusKey = 'status';
+  private readonly limitKey = 'limit';
+  private readonly orderKey = 'orderBy';
 
   /**
    * Get all the todos from the server, filtered by the information
@@ -49,7 +51,7 @@ export class TodoService {
    *  from the server after a possibly substantial delay (because we're
    *  contacting a remote server over the Internet).
    */
-  getTodos(filters?: {status?: string; body?: string; }): Observable<Todo[]> {
+  getTodos(filters?: {status?: string; body?: string; limit?: number; orderBy?: string;}): Observable<Todo[]> {
     // `HttpParams` is essentially just a map used to hold key-value
     // pairs that are then encoded as "?key1=value1&key2=value2&…" in
     // the URL when we make the call to `.get()` below.
@@ -60,6 +62,12 @@ export class TodoService {
       }
       if (filters.body) {
         httpParams = httpParams.set(this.bodyKey, filters.body);
+      }
+      if (filters.limit) {
+        httpParams = httpParams.set(this.limitKey, filters.limit);
+      }
+      if (filters.orderBy) {
+        httpParams = httpParams.set(this.orderKey, filters.orderBy);
       }
     }
     // Send the HTTP GET request with the given URL and parameters.

--- a/client/src/testing/todo.service.mock.ts
+++ b/client/src/testing/todo.service.mock.ts
@@ -41,7 +41,7 @@ export class MockTodoService implements Pick<TodoService, 'getTodos' | 'getTodoB
   // It's OK that the `_filters` argument isn't used here, so we'll disable
   // this warning for just his function.
   /* eslint-disable @typescript-eslint/no-unused-vars */
-  getTodos(_filters: {status?: string; body?: string; }): Observable<Todo[]> {
+  getTodos(_filters: {status?: string; body?: string; limit?: number; orderBy?: string;}): Observable<Todo[]> {
     // Our goal here isn't to test (and thus rewrite) the service, so we'll
     // keep it simple and just return the test todos regardless of what
     // filters are passed in.
@@ -75,6 +75,8 @@ export class MockTodoService implements Pick<TodoService, 'getTodos' | 'getTodoB
   filterTodos(todos: Todo[], filters: {
     status?: string;
     body?: string;
+    limit?: number;
+    orderBy?: string;
   }): Todo[] {
     return []
   }


### PR DESCRIPTION
Within his branch, server-side filtering for limiting todos and ordering those todos by status have been added with HTML formatting. Additionally, tests for the limit and order functions have been created accordingly.

Co-authored-by: Pierce Richards <rich2029@morris.umn.edu>